### PR TITLE
Neermita18/add api stats endpoint

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,8 +6,11 @@ import { Brain, Users, Target, Award, Lightbulb, Heart, Globe, Zap, Sparkles, Ro
 import Link from "next/link";
 import { useState } from "react";
 import MobileMenu from "@/components/MobileMenu";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/store";
 
 export default function AboutPage() {
+	const stats = useSelector((state: RootState) => state.stats);
 	const team = [
 		{
 			name: "Piyush Dixit",
@@ -146,13 +149,13 @@ export default function AboutPage() {
 					<div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-20 animate-fade-in-up animation-delay-400">
 						{[
 							{
-								number: "1K+",
+								number: stats.totalUsers.toLocaleString(),
 								label: "Active Users",
 								icon: <Users className="w-6 h-6" />,
 								gradient: "from-blue-400 to-cyan-400",
 							},
 							{
-								number: "2M+",
+								number: stats.totalParsedDocuments.toLocaleString(),
 								label: "Documents Processed",
 								icon: <Brain className="w-6 h-6" />,
 								gradient: "from-green-400 to-emerald-400",

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -71,4 +71,4 @@ const authOptions: NextAuthOptions = {
 };
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST, authOptions };
+export { handler as GET, handler as POST };

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -71,4 +71,4 @@ const authOptions: NextAuthOptions = {
 };
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, authOptions };

--- a/app/api/parse-pdf/route.ts
+++ b/app/api/parse-pdf/route.ts
@@ -1,13 +1,11 @@
 import axios from "axios";
 import { NextRequest } from "next/server";
 import pdfParse from "pdf-parse";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { prisma } from "@/lib/prisma";
-
+import { getToken } from "next-auth/jwt";
 export async function POST(req: NextRequest) {
-  const session = await getServerSession(authOptions);
-	if (!session || !session.user?.email) 
+  const token = await getToken({ req, secret: process.env.AUTH_SECRET });
+	if (!token) 
 	{
 		return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
 	}
@@ -153,7 +151,7 @@ ${textContent}`;
 			}
 
 			const user = await prisma.user.findUnique({
-				where: { email: session.user.email! },
+				where: { email: token.email! },
 				});
 
 				if (!user) {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -4,11 +4,13 @@ export async function GET() {
   try {
     const userCount = await prisma.user.count();
     const documentCount = await prisma.parsedDocument.count();
-    console.log(`Number of users: ${userCount}, number of documents parsed: ${documentCount}`)
+    const flashcards = await prisma.parsedDocument.count() * 4;
+    console.log(`Number of users: ${userCount}, number of documents parsed: ${documentCount}, number of flashcards created: ${flashcards}`)
 
     return NextResponse.json({
       totalUsers: userCount,
       totalParsedDocuments: documentCount,
+      totalFlashcards: flashcards
     });
   } catch (error) {
     console.error("Error fetching stats:", error);

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+export async function GET() {
+  try {
+    const userCount = await prisma.user.count();
+    const documentCount = await prisma.parsedDocument.count();
+    console.log(`Number of users: ${userCount}, number of documents parsed: ${documentCount}`)
+
+    return NextResponse.json({
+      totalUsers: userCount,
+      totalParsedDocuments: documentCount,
+    });
+  } catch (error) {
+    console.error("Error fetching stats:", error);
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import StoreProvider from "./store-provider";
 import { SessionProviderC } from "@/components/SessionProviderC";
 import { LoadingProvider } from "@/components/loading-provider";
-
+import StatsInitializer from "@/components/StatsInitializer";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange={false}>
 					<LoadingProvider>
 						<SessionProviderC>
-							<StoreProvider>{children}</StoreProvider>
+							<StoreProvider><StatsInitializer/>{children}</StoreProvider>
 						</SessionProviderC>
 					</LoadingProvider>
 				</ThemeProvider>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -6,8 +6,11 @@ import { Check, Star, Zap, Crown, Rocket, X } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import MobileMenu from "@/components/MobileMenu";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/store";
 
 export default function PricingPage() {
+	const stats = useSelector((state: RootState) => state.stats);
 	const plans = [
 		{
 			name: "Free",
@@ -178,7 +181,7 @@ export default function PricingPage() {
 					<div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-20 animate-fade-in-up animation-delay-400">
 						<div className="text-center group">
 							<div className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent mb-2 group-hover:scale-110 transition-transform duration-300">
-								50K+
+								{stats.totalParsedDocuments.toLocaleString()}
 							</div>
 							<div className="text-gray-500 text-sm">Documents Processed</div>
 						</div>
@@ -190,7 +193,7 @@ export default function PricingPage() {
 						</div>
 						<div className="text-center group">
 							<div className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent mb-2 group-hover:scale-110 transition-transform duration-300">
-								15K+
+								{stats.totalUsers.toLocaleString()}
 							</div>
 							<div className="text-gray-500 text-sm">Happy Users</div>
 						</div>

--- a/components/StatsInitializer.tsx
+++ b/components/StatsInitializer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { setStats } from "../lib/store/slices/statsSlice"; 
+import axios from "axios";
+
+export default function StatsInitializer() {
+	const dispatch = useDispatch();
+
+    useEffect(() => {
+    const fetchStats = async () => {
+        try {
+        const res = await axios.get("/api/stats");
+        dispatch(setStats(res.data));
+        } catch (err) {
+        console.error("Failed to fetch stats:", err);
+        }
+    };
+
+    fetchStats(); // initial fetch
+
+}, []);
+
+
+	return null; 
+}

--- a/components/StatsInitializer.tsx
+++ b/components/StatsInitializer.tsx
@@ -6,22 +6,21 @@ import { setStats } from "../lib/store/slices/statsSlice";
 import axios from "axios";
 
 export default function StatsInitializer() {
-	const dispatch = useDispatch();
+  const dispatch = useDispatch();
 
-    useEffect(() => {
+  useEffect(() => {
+    // Fetch stats once on mount
     const fetchStats = async () => {
-        try {
+      try {
         const res = await axios.get("/api/stats");
         dispatch(setStats(res.data));
-        } catch (err) {
+      } catch (err) {
         console.error("Failed to fetch stats:", err);
-        }
+      }
     };
 
-    fetchStats(); // initial fetch
+    fetchStats();
+  }, [dispatch]);
 
-}, []);
-
-
-	return null; 
+  return null;
 }

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -2,11 +2,14 @@
 import { Button } from "@/components/ui/button";
 import { ArrowRight, Zap, Sparkles, Brain, Rocket } from "lucide-react";
 import { useSession } from "next-auth/react";
+import { useSelector } from "react-redux";
+import { RootState } from "@/lib/store";
 
 export function HeroSection() {
 	const handleGetStarted = () => {
 		window.location.href = "/signin";
 	};
+	const stats = useSelector((state: RootState) => state.stats);
 	const user = useSession().data?.user;
 	return (
 		<div className="relative bg-gradient-to-br from-primary/10 via-purple-50/50 to-pink-50/30 dark:from-primary/5 dark:via-purple-950/20 dark:to-pink-950/10 pt-20 pb-16 overflow-hidden">
@@ -71,11 +74,11 @@ export function HeroSection() {
 				{/* Floating stats */}
 				<div className="flex justify-center gap-8 mt-16 animate-fade-in-up animation-delay-600">
 					<div className="text-center group hover:scale-110 transition-all duration-300">
-						<div className="text-2xl font-bold text-gradient-blue-cyan">10K+</div>
+						<div className="text-2xl font-bold text-gradient-blue-cyan">{stats.totalParsedDocuments.toLocaleString()}</div>
 						<div className="text-sm text-muted-foreground">Documents Processed</div>
 					</div>
 					<div className="text-center group hover:scale-110 transition-all duration-300">
-						<div className="text-2xl font-bold text-gradient-green-emerald">50K+</div>
+						<div className="text-2xl font-bold text-gradient-green-emerald">{stats.totalFlashcards.toLocaleString()}</div>
 						<div className="text-sm text-muted-foreground">Flashcards Created</div>
 					</div>
 					<div className="text-center group hover:scale-110 transition-all duration-300">

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import parseReducer from "./slices/parseSlice";
 import chatReducer from "./slices/chatSlice";
+import statsReducer from "./slices/statsSlice";
 export const store = configureStore({
 	reducer: {
 		parse: parseReducer,
 		chat: chatReducer,
+		stats: statsReducer,
 	},
 });
 

--- a/lib/store/slices/statsSlice.ts
+++ b/lib/store/slices/statsSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface StatsState {
+  totalUsers: number;
+  totalParsedDocuments: number;
+  totalFlashcards: number;
+}
+
+const initialState: StatsState = {
+  totalUsers: 0,
+  totalParsedDocuments: 0,
+  totalFlashcards: 0,
+};
+
+const statsSlice = createSlice({
+  name: "stats",
+  initialState,
+  reducers: {
+    setStats(state, action: PayloadAction<StatsState>) {
+      state.totalUsers = action.payload.totalUsers;
+      state.totalParsedDocuments = action.payload.totalParsedDocuments;
+      state.totalFlashcards = action.payload.totalFlashcards;
+    },
+    resetStats(state) {
+      state.totalUsers = 0;
+      state.totalParsedDocuments = 0;
+      state.totalFlashcards = 0;
+    },
+  },
+});
+
+export const { setStats, resetStats } = statsSlice.actions;
+export default statsSlice.reducer;

--- a/prisma/migrations/20250722084709_add_parsed_document/migration.sql
+++ b/prisma/migrations/20250722084709_add_parsed_document/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "ParsedDocument" (
+    "id" TEXT NOT NULL,
+    "docName" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ParsedDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ParsedDocument" ADD CONSTRAINT "ParsedDocument_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
+  parsedDocs    ParsedDocument[] 
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -65,4 +66,13 @@ model VerificationToken {
   expires    DateTime
 
   @@id([identifier, token])
+}
+
+model ParsedDocument {
+  id        String   @id @default(cuid())
+  docName   String
+  content   String
+  createdAt DateTime @default(now())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
Previously, statistics such as the number of active users, documents processed, and flashcards created were hardcoded. These were the changes -
fixed #13 
**Database Schema Update:**
A new table named ParsedDocuments was added to the Prisma schema. This enables querying various metrics like:
Total documents parsed
Total number of active users
Flashcards created (docs * 4)
(Can be extended to define metrics like - Documents parsed per user, etc,.)

**API Endpoint:**
An API route (/api/stats) was created to aggregate and serve real-time statistics from the database.

**Redux Integration:**
A new Redux slice (statsSlice) was added to manage these stats in the global store. 

**Client-Side Initialization:**
A StatsInitializer component was created and included in the top-level layout.tsx. On initial load, it fetches stats from the API and populates the Redux store. These stats are read from Redux in components like the Homepage, About and Pricing page. 

