### PR TITLE
feat: Added Summary Length Selection by the User

### DIFF
--- a/components/file-uploader.tsx
+++ b/components/file-uploader.tsx
@@ -22,6 +22,7 @@ export function FileUploader() {
 	const [progress, setProgress] = useState(0);
 	const [error, setError] = useState<string | null>(null);
 	const [dragActive, setDragActive] = useState(false);
+	const [summaryLength, setSummaryLength] = useState<'short' | 'medium' | 'long'>('short');
 	const router = useRouter();
 	const session = useSession();
 
@@ -84,6 +85,7 @@ export function FileUploader() {
 		const formData = new FormData();
 		formData.append("file", file);
 		formData.append("type", file.type);
+		formData.append("summaryLength", summaryLength);
 
 		try {
 			const res = await axios.post(`/api/parse-pdf`, formData);
@@ -133,6 +135,43 @@ export function FileUploader() {
 		<form onSubmit={handleSubmit} className="space-y-6">
 			{error && <Toast message={error} type="error" onClose={() => setError(null)} />}
 			<div className="grid w-full gap-4">
+				{/* Summary Length Selection */}
+				<div className="space-y-3">
+					<label className="text-sm font-medium text-foreground">Summary Length</label>
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							variant={summaryLength === 'short' ? 'default' : 'outline'}
+							size="sm"
+							onClick={() => setSummaryLength('short')}
+							className={`flex-1 ${summaryLength === 'short' ? 'bg-violet-500 hover:bg-violet-700' : ''}`}
+						>
+							Short
+							<span className="text-xs ml-1 opacity-75">(3-4 points)</span>
+						</Button>
+						<Button
+							type="button"
+							variant={summaryLength === 'medium' ? 'default' : 'outline'}
+							size="sm"
+							onClick={() => setSummaryLength('medium')}
+							className={`flex-1 ${summaryLength === 'medium' ? 'bg-violet-500 hover:bg-violet-700' : ''}`}
+						>
+							Medium
+							<span className="text-xs ml-1 opacity-75">(6-8 points)</span>
+						</Button>
+						<Button
+							type="button"
+							variant={summaryLength === 'long' ? 'default' : 'outline'}
+							size="sm"
+							onClick={() => setSummaryLength('long')}
+							className={`flex-1 ${summaryLength === 'long' ? 'bg-violet-500 hover:bg-violet-700' : ''}`}
+						>
+							Long
+							<span className="text-xs ml-1 opacity-75">(9-10 points)</span>
+						</Button>
+					</div>
+				</div>
+
 				<div
 					className={`relative flex flex-col items-center justify-center p-8 border-2 border-dashed rounded-xl cursor-pointer transition-all duration-300 ${
 						dragActive


### PR DESCRIPTION
Introduces a summary length option in the file uploader UI, allowing users to choose between short, medium, or long summaries. The selected length is sent to the backend, which dynamically adjusts the number of main points generated in the summary response.

<img width="1919" height="896" alt="image" src="https://github.com/user-attachments/assets/6bb1ad43-de02-4b58-bbdd-36d28994bec9" />

This creates the summary based on the number of points chosen by the user. An example is as follows:
Short: 
<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/dd579c36-9076-4ab2-8d7f-21ca463aa73f" />

Medium:
<img width="1919" height="902" alt="image" src="https://github.com/user-attachments/assets/d9422da9-8454-4209-8c36-58818e8ad1b2" />

Long:
<img width="1919" height="899" alt="image" src="https://github.com/user-attachments/assets/b936b2e4-8ff9-4da4-a5c4-312b32952fc0" />

This feature is especially useful for longer documents that may require more points to summarize the entire document. 

---

Hey @Er-luffy-D ! Could you please review this PR and let me know if everything's fine!